### PR TITLE
修复重载方法参数有基本数据类型时报错问题

### DIFF
--- a/any-door-common/src/main/java/io/github/lgp547/anydoor/common/util/AnyDoorClassUtil.java
+++ b/any-door-common/src/main/java/io/github/lgp547/anydoor/common/util/AnyDoorClassUtil.java
@@ -1,15 +1,33 @@
 package io.github.lgp547.anydoor.common.util;
 
-
 import java.lang.reflect.Method;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 
 public class AnyDoorClassUtil {
 
+    private static final Map<String, Class<?>> PRIMITIVE_TYPE_MAP = new HashMap<>();
+
+    static {
+        PRIMITIVE_TYPE_MAP.put("byte", byte.class);
+        PRIMITIVE_TYPE_MAP.put("short", short.class);
+        PRIMITIVE_TYPE_MAP.put("int", int.class);
+        PRIMITIVE_TYPE_MAP.put("long", long.class);
+        PRIMITIVE_TYPE_MAP.put("float", float.class);
+        PRIMITIVE_TYPE_MAP.put("double", double.class);
+        PRIMITIVE_TYPE_MAP.put("char", char.class);
+        PRIMITIVE_TYPE_MAP.put("boolean", boolean.class);
+    }
+
     public static Class<?> forName(String className) {
+        Class<?> clazz = PRIMITIVE_TYPE_MAP.get(className);
+        if (clazz != null) {
+            return clazz;
+        }
         try {
             return Class.forName(className);
         } catch (Exception e) {

--- a/any-door-core/src/test/java/io/github/lgp547/anydoor/test/core/Bean.java
+++ b/any-door-core/src/test/java/io/github/lgp547/anydoor/test/core/Bean.java
@@ -72,6 +72,22 @@ public class Bean {
 
     public static final Permission permission = new Permission(1L, "permissionName");
 
+    public static final int intValue = 1;
+
+    public static final long longValue = 1L;
+
+    public static final float floatValue = 1.0f;
+
+    public static final double doubleValue = 1.0d;
+
+    public static final boolean booleanValue = true;
+
+    public static final char charValue = 'a';
+
+    public static final byte byteValue = 1;
+
+    public static final short shortValue = 1;
+
     public static JsonNode getContent() {
         ObjectNode jsonNode = new ObjectNode(JsonNodeFactory.instance);
         jsonNode.put("id", id);
@@ -94,6 +110,14 @@ public class Bean {
         jsonNode.put("dateTimeByCom1", dateTimeByCom1);
         jsonNode.putPOJO("longs", longs);
         jsonNode.putPOJO("permission", permission);
+        jsonNode.put("intValue", intValue);
+        jsonNode.put("longValue", longValue);
+        jsonNode.put("floatValue", floatValue);
+        jsonNode.put("doubleValue", doubleValue);
+        jsonNode.put("booleanValue", booleanValue);
+        jsonNode.put("charValue", charValue);
+        jsonNode.put("byteValue", byteValue);
+        jsonNode.put("shortValue", shortValue);
         return jsonNode;
     }
 
@@ -236,4 +260,21 @@ public class Bean {
     public void testBuilder(Permission permission) {
         assertIsEquals(Bean.permission, permission);
     }
+
+    public void testPrimitiveType(int intValue, long longValue, double doubleValue, float floatValue,
+                                  boolean booleanValue, char charValue, byte byteValue, short shortValue) {
+        assertIsEquals(intValue, Bean.intValue);
+        assertIsEquals(longValue, Bean.longValue);
+        assertIsEquals(doubleValue, Bean.doubleValue);
+        assertIsEquals(floatValue, Bean.floatValue);
+        assertIsEquals(booleanValue, Bean.booleanValue);
+        assertIsEquals(charValue, Bean.charValue);
+        assertIsEquals(byteValue, Bean.byteValue);
+        assertIsEquals(shortValue, Bean.shortValue);
+    }
+
+    public void testPrimitiveType(int intValue) {
+        assertIsEquals(intValue, Bean.intValue);
+    }
+
 }


### PR DESCRIPTION
现有逻辑在执行带有基本数据类型的时候会报错
```java
import java.io.IOException;

public class Main {
    public static void main(String[] args) throws IOException {
        System.in.read();
    }

    public static void method1(int num) {
        System.out.println("method1");
    }

    public static void method1(int num, int num2) {
        System.out.println("method1");
    }

}
```