### PR TITLE
修复插件参数模板生成异常

### DIFF
--- a/any-door-plugin/build.gradle.kts
+++ b/any-door-plugin/build.gradle.kts
@@ -9,6 +9,7 @@ group = "io.github.lgp547"
 version = "2.2.2"
 
 repositories {
+    mavenLocal()
     mavenCentral()
     // todo：自行修改成本地maven仓库地址
     mavenLocal {

--- a/any-door-plugin/src/main/java/io/github/lgp547/anydoorplugin/dialog/MethodDataContext.java
+++ b/any-door-plugin/src/main/java/io/github/lgp547/anydoorplugin/dialog/MethodDataContext.java
@@ -6,6 +6,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Predicate;
 
+import com.intellij.openapi.application.ReadAction;
 import com.intellij.openapi.project.Project;
 import com.intellij.psi.PsiClass;
 import com.intellij.psi.PsiMethod;
@@ -129,24 +130,28 @@ public class MethodDataContext implements Multicaster, Listener {
 
     @Nullable
     public PsiMethod getMethod() {
-        String simpleMethodName = IdeClassUtil.getSimpleMethodName(qualifiedMethodName);
-        if (Objects.nonNull(classDataContext.clazz)) {
-            PsiMethod[] methods = classDataContext.clazz.findMethodsByName(simpleMethodName, false);
-            for (PsiMethod method : methods) {
-                if (Objects.equals(qualifiedMethodName, IdeClassUtil.getMethodQualifiedName(method))) {
-                    return method;
+        return ReadAction.compute(() -> {
+            String simpleMethodName = IdeClassUtil.getSimpleMethodName(qualifiedMethodName);
+            if (Objects.nonNull(classDataContext.clazz)) {
+                PsiMethod[] methods = classDataContext.clazz.findMethodsByName(simpleMethodName, false);
+                for (PsiMethod method : methods) {
+                    if (Objects.equals(qualifiedMethodName, IdeClassUtil.getMethodQualifiedName(method))) {
+                        return method;
+                    }
                 }
             }
-        }
-        return null;
+            return null;
+        });
     }
 
     public PsiParameterList getParamList() {
-        PsiMethod method = getMethod();
-        if (Objects.isNull(method)) {
-            return new PsiParameterListImpl(new PsiParameterListStubImpl(null));
-        }
-        return method.getParameterList();
+        return ReadAction.compute(() -> {
+            PsiMethod method = getMethod();
+            if (Objects.isNull(method)) {
+                return new PsiParameterListImpl(new PsiParameterListStubImpl(null));
+            }
+            return method.getParameterList();
+        });
     }
 
     @Override
@@ -177,21 +182,9 @@ public class MethodDataContext implements Multicaster, Listener {
             updateItemName(dataItem);
             flush();
         } else if (Objects.equals(event.getType(), EventType.ADD_SIMPLE_PARAM_ITEM)) {
-            findItem(null)
-                    .ifPresentOrElse(
-                            item -> {
-                                item.setParam(JsonElementUtil.getSimpleText(getParamList()));
-                                selectItem(item);
-                            },
-                            this::resetEmptyItem);
+            resetSimpleParamItem();
         } else if (Objects.equals(event.getType(), EventType.ADD_ALL_PARAM_ITEM)) {
-            findItem(null)
-                    .ifPresentOrElse(
-                            item -> {
-                                item.setParam(JsonElementUtil.getJsonText(getParamList()));
-                                selectItem(item);
-                            },
-                            this::resetEmptyItemFillParam);
+            resetAllParamItem();
         } else if (Objects.equals(event.getType(), EventType.ADD_CACHE_PARAM_ITEM)) {
             resetLastCacheParam();
         }
@@ -204,13 +197,29 @@ public class MethodDataContext implements Multicaster, Listener {
     }
 
     private void resetEmptyItemFillParam() {
-        resetEmptyItem();
-        freeItem.setParam(JsonElementUtil.getJsonText(getParamList()));
+        resetAllParamItem();
     }
 
     private void resetEmptyItem() {
-        freeItem = new ParamDataItem("", qualifiedMethodName, JsonElementUtil.getSimpleText(getParamList()));
+        resetAllParamItem();
+    }
+
+    private void resetSimpleParamItem() {
+        freeItem = new ParamDataItem("", qualifiedMethodName, getSimpleParamText());
         selectItem(freeItem);
+    }
+
+    private void resetAllParamItem() {
+        freeItem = new ParamDataItem("", qualifiedMethodName, getAllParamText());
+        selectItem(freeItem);
+    }
+
+    private String getSimpleParamText() {
+        return ReadAction.compute(() -> JsonElementUtil.getSimpleText(getParamList()));
+    }
+
+    private String getAllParamText() {
+        return ReadAction.compute(() -> JsonElementUtil.getJsonText(getParamList()));
     }
 
     private void resetLastCacheParam() {

--- a/any-door-plugin/src/main/java/io/github/lgp547/anydoorplugin/dialog/components/MainPanel.java
+++ b/any-door-plugin/src/main/java/io/github/lgp547/anydoorplugin/dialog/components/MainPanel.java
@@ -49,7 +49,7 @@ public class MainPanel extends JBPanel<MainPanel> implements Listener {
         this.context = context;
 
         toolBar = new MyToolBar(project, context);
-        editor = new MyEditor(context, context.cacheContent, context.getParamList(), project);
+        editor = new MyEditor(context, context.getSelectedItem().getParam(), context.getParamList(), project);
 //        comboBox = new MyComboBox(project, context);
 //        saveParamButton = new JButton("Save");
         runNum = new JBIntSpinner(1, 1, Integer.MAX_VALUE);

--- a/any-door-plugin/src/main/java/io/github/lgp547/anydoorplugin/util/JsonElementUtil.java
+++ b/any-door-plugin/src/main/java/io/github/lgp547/anydoorplugin/util/JsonElementUtil.java
@@ -10,6 +10,7 @@ import com.google.gson.JsonPrimitive;
 import com.intellij.psi.PsiClass;
 import com.intellij.psi.PsiClassType;
 import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiModifier;
 import com.intellij.psi.PsiParameter;
 import com.intellij.psi.PsiParameterList;
 import com.intellij.psi.PsiType;
@@ -18,7 +19,6 @@ import com.intellij.psi.PsiWhiteSpace;
 import com.intellij.psi.impl.source.tree.LeafPsiElement;
 import com.intellij.psi.impl.source.tree.PsiErrorElementImpl;
 import org.apache.commons.lang3.ClassUtils;
-import org.apache.commons.lang3.StringUtils;
 
 import java.net.URI;
 import java.net.URL;
@@ -99,7 +99,7 @@ public class JsonElementUtil {
                     }
                     JsonObject jsonObject1 = new JsonObject();
                     Arrays.stream(psiClass.getAllFields()).forEach(field -> {
-                        if (!StringUtils.contains(field.getText(), " static ") && num < 5) {
+                        if (!field.hasModifierProperty(PsiModifier.STATIC) && num < 5) {
                             jsonObject1.add(field.getName(), toJson(field.getType(), num + 1));
                         }
                     });


### PR DESCRIPTION
## 变更内容

- 修复 Example For All Param 首次生成时未展开 DTO 字段的问题。
- 将 IDEA PSI 读取包装到 ReadAction，避免 IDEA 2024.3 下点击按钮时报 Read access 异常。
- 参数模板生成时复用全量参数重建逻辑，并过滤 static 字段。
- 为插件 Gradle 构建补充 mavenLocal() 依赖源。

## 验证

- mvn test
- any-door-plugin: gradle compileJava
- git diff --check
