### PR TITLE
修复对话框回调中的 PSI 读取异常

### DIFF
--- a/any-door-plugin/build.gradle.kts
+++ b/any-door-plugin/build.gradle.kts
@@ -20,6 +20,7 @@ repositories {
 dependencies {
     implementation("io.github.lgp547:any-door-core:2.2.2")
     implementation("io.github.lgp547:any-door-attach:2.2.2")
+    testImplementation("junit:junit:4.13.2")
 
 }
 

--- a/any-door-plugin/build.gradle.kts
+++ b/any-door-plugin/build.gradle.kts
@@ -9,6 +9,7 @@ group = "io.github.lgp547"
 version = "2.2.2"
 
 repositories {
+    mavenLocal()
     mavenCentral()
     // todo：自行修改成本地maven仓库地址
     mavenLocal {

--- a/any-door-plugin/src/main/java/io/github/lgp547/anydoorplugin/action/AnyDoorPerformed.java
+++ b/any-door-plugin/src/main/java/io/github/lgp547/anydoorplugin/action/AnyDoorPerformed.java
@@ -8,7 +8,6 @@ import io.github.lgp547.anydoorplugin.AnyDoorInfo;
 import io.github.lgp547.anydoorplugin.dialog.DataContext;
 import io.github.lgp547.anydoorplugin.dialog.MainUI;
 import io.github.lgp547.anydoorplugin.dialog.old.TextAreaDialog;
-import io.github.lgp547.anydoorplugin.dialog.utils.IdeClassUtil;
 import io.github.lgp547.anydoorplugin.dto.ParamCacheDto;
 import io.github.lgp547.anydoorplugin.settings.AnyDoorSettingsState;
 import io.github.lgp547.anydoorplugin.util.AnyDoorActionUtil;
@@ -30,10 +29,7 @@ import java.util.function.BiConsumer;
 public class AnyDoorPerformed {
 
     public void invoke(Project project, PsiMethod psiMethod, Runnable okAction) {
-        PsiClass psiClass = (PsiClass) psiMethod.getParent();
-        String className = psiClass.getQualifiedName();
-        String methodName = psiMethod.getName();
-        List<String> paramTypeNameList = AnyDoorActionUtil.toParamTypeNameList(psiMethod.getParameterList());
+        MethodInvocationSnapshot method = MethodInvocationSnapshot.capture(psiMethod);
 
 
         Optional<AnyDoorSettingsState> anyDoorSettingsStateOpt = AnyDoorSettingsState.getAnyDoorSettingsStateNotExc(project);
@@ -45,16 +41,16 @@ public class AnyDoorPerformed {
         BiConsumer<String, Exception> openExcConsumer = (url, e) -> NotifierUtil.notifyError(project, "call " + url + " error [ " + e.getMessage() + " ]");
 
 
-        if (paramTypeNameList.isEmpty()) {
-            String jsonDtoStr = getJsonDtoStr(project, className, methodName, paramTypeNameList, "{}", !service.enableAsyncExecute, null);
+        if (method.parameterTypeNames().isEmpty()) {
+            String jsonDtoStr = getJsonDtoStr(project, method.className(), method.methodName(), method.parameterTypeNames(), "{}", !service.enableAsyncExecute, null);
             openAnyDoor(project, jsonDtoStr, service, openExcConsumer);
             okAction.run();
         } else {
-            String cacheKey = AnyDoorActionUtil.genCacheKey(psiClass, psiMethod);
-            if (useNewUI(service, project, psiClass, psiMethod, cacheKey, okAction)) {
+            String cacheKey = AnyDoorActionUtil.genCacheKey(method.className(), method.methodName(), method.parameterTypeNames());
+            if (useNewUI(service, project, method, cacheKey, okAction)) {
                 return;
             }
-            TextAreaDialog dialog = new TextAreaDialog(project, String.format("fill method(%s) param", methodName), psiMethod.getParameterList(), service.getCache(cacheKey), service);
+            TextAreaDialog dialog = new TextAreaDialog(project, String.format("fill method(%s) param", method.methodName()), psiMethod.getParameterList(), service.getCache(cacheKey), service);
             dialog.setOkAction(() -> {
                 okAction.run();
                 if (dialog.isChangePid()) {
@@ -64,11 +60,11 @@ public class AnyDoorPerformed {
                 ParamCacheDto paramCacheDto = new ParamCacheDto(dialog.getRunNum(), dialog.getIsConcurrent(), text);
                 service.putCache(cacheKey, paramCacheDto);
                 // Change to args for the interface type
-                if (psiClass.isInterface()) {
-                    text = JsonUtil.transformedKey(text, AnyDoorActionUtil.getParamTypeNameTransformer(psiMethod.getParameterList()));
+                if (method.interfaceType()) {
+                    text = JsonUtil.transformedKey(text, method.parameterNameTransformer());
                 }
                 text = JsonUtil.compressJson(text);
-                String jsonDtoStr = getJsonDtoStr(project, className, methodName, paramTypeNameList, text, !service.enableAsyncExecute, paramCacheDto);
+                String jsonDtoStr = getJsonDtoStr(project, method.className(), method.methodName(), method.parameterTypeNames(), text, !service.enableAsyncExecute, paramCacheDto);
                 openAnyDoor(project, jsonDtoStr, service, openExcConsumer);
             });
             dialog.show();
@@ -83,10 +79,23 @@ public class AnyDoorPerformed {
         return false;
     }
 
+    private boolean useNewUI(AnyDoorSettingsState service, Project project, MethodInvocationSnapshot method, String cacheKey, Runnable okAction) {
+        if (service.enableNewUI) {
+            doUseNewUI(service, project, method, cacheKey, okAction, null);
+            return true;
+        }
+        return false;
+    }
+
     public void doUseNewUI(AnyDoorSettingsState service, Project project, PsiClass psiClass, PsiMethod psiMethod, String cacheKey, Runnable okAction, @Nullable Long selectedId) {
+        MethodInvocationSnapshot method = MethodInvocationSnapshot.capture(psiClass, psiMethod);
+        doUseNewUI(service, project, method, cacheKey, okAction, selectedId);
+    }
+
+    private void doUseNewUI(AnyDoorSettingsState service, Project project, MethodInvocationSnapshot method, String cacheKey, Runnable okAction, @Nullable Long selectedId) {
         ParamCacheDto cache = service.getCache(cacheKey);
         DataContext instance = DataContext.instance(project);
-        MainUI mainUI = new MainUI(psiMethod.getName(), project, instance.getExecuteDataContext(psiClass.getQualifiedName(), IdeClassUtil.getMethodQualifiedName(psiMethod), selectedId, cache.content()));
+        MainUI mainUI = new MainUI(method.methodName(), project, instance.getExecuteDataContext(method.className(), method.qualifiedMethodName(), selectedId, cache.content()));
         mainUI.setOkAction((text) -> {
             okAction.run();
             if (mainUI.isChangePid()) {
@@ -96,10 +105,10 @@ public class AnyDoorPerformed {
             ParamCacheDto paramCacheDto = new ParamCacheDto(mainUI.getRunNum(), mainUI.getIsConcurrent(), text);
             service.putCache(cacheKey, paramCacheDto);
 
-            if (psiClass.isInterface()) {
-                text = JsonUtil.transformedKey(text, AnyDoorActionUtil.getParamTypeNameTransformer(psiMethod.getParameterList()));
+            if (method.interfaceType()) {
+                text = JsonUtil.transformedKey(text, method.parameterNameTransformer());
             }
-            String jsonDtoStr = getJsonDtoStr(project, psiClass.getQualifiedName(), psiMethod.getName(), AnyDoorActionUtil.toParamTypeNameList(psiMethod.getParameterList()), text, !service.enableAsyncExecute, paramCacheDto);
+            String jsonDtoStr = getJsonDtoStr(project, method.className(), method.methodName(), method.parameterTypeNames(), text, !service.enableAsyncExecute, paramCacheDto);
             openAnyDoor(project, jsonDtoStr, service, (url, e) -> NotifierUtil.notifyError(project, "call " + url + " error [ " + e.getMessage() + " ]"));
         });
         mainUI.show();

--- a/any-door-plugin/src/main/java/io/github/lgp547/anydoorplugin/action/MethodInvocationSnapshot.java
+++ b/any-door-plugin/src/main/java/io/github/lgp547/anydoorplugin/action/MethodInvocationSnapshot.java
@@ -1,0 +1,52 @@
+package io.github.lgp547.anydoorplugin.action;
+
+import com.intellij.openapi.application.ReadAction;
+import com.intellij.psi.PsiClass;
+import com.intellij.psi.PsiMethod;
+import com.intellij.psi.PsiParameterList;
+import io.github.lgp547.anydoorplugin.dialog.utils.IdeClassUtil;
+import io.github.lgp547.anydoorplugin.util.AnyDoorActionUtil;
+
+import java.util.List;
+import java.util.Map;
+
+record MethodInvocationSnapshot(
+        String className,
+        String methodName,
+        String qualifiedMethodName,
+        List<String> parameterTypeNames,
+        Map<String, String> parameterNameTransformer,
+        boolean interfaceType
+) {
+
+    MethodInvocationSnapshot {
+        parameterTypeNames = List.copyOf(parameterTypeNames);
+        parameterNameTransformer = Map.copyOf(parameterNameTransformer);
+    }
+
+    static MethodInvocationSnapshot capture(PsiMethod psiMethod) {
+        return ReadAction.compute(() -> captureInsideReadAction(
+                (PsiClass) psiMethod.getParent(),
+                psiMethod
+        ));
+    }
+
+    static MethodInvocationSnapshot capture(PsiClass psiClass, PsiMethod psiMethod) {
+        return ReadAction.compute(() -> captureInsideReadAction(psiClass, psiMethod));
+    }
+
+    private static MethodInvocationSnapshot captureInsideReadAction(
+            PsiClass psiClass,
+            PsiMethod psiMethod
+    ) {
+        PsiParameterList parameterList = psiMethod.getParameterList();
+        return new MethodInvocationSnapshot(
+                psiClass.getQualifiedName(),
+                psiMethod.getName(),
+                IdeClassUtil.getMethodQualifiedName(psiMethod),
+                AnyDoorActionUtil.toParamTypeNameList(parameterList),
+                AnyDoorActionUtil.getParamTypeNameTransformer(parameterList),
+                psiClass.isInterface()
+        );
+    }
+}

--- a/any-door-plugin/src/main/java/io/github/lgp547/anydoorplugin/dialog/MethodDataContext.java
+++ b/any-door-plugin/src/main/java/io/github/lgp547/anydoorplugin/dialog/MethodDataContext.java
@@ -6,6 +6,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Predicate;
 
+import com.intellij.openapi.application.ReadAction;
 import com.intellij.openapi.project.Project;
 import com.intellij.psi.PsiClass;
 import com.intellij.psi.PsiMethod;
@@ -129,24 +130,28 @@ public class MethodDataContext implements Multicaster, Listener {
 
     @Nullable
     public PsiMethod getMethod() {
-        String simpleMethodName = IdeClassUtil.getSimpleMethodName(qualifiedMethodName);
-        if (Objects.nonNull(classDataContext.clazz)) {
-            PsiMethod[] methods = classDataContext.clazz.findMethodsByName(simpleMethodName, false);
-            for (PsiMethod method : methods) {
-                if (Objects.equals(qualifiedMethodName, IdeClassUtil.getMethodQualifiedName(method))) {
-                    return method;
+        return ReadAction.compute(() -> {
+            String simpleMethodName = IdeClassUtil.getSimpleMethodName(qualifiedMethodName);
+            if (Objects.nonNull(classDataContext.clazz)) {
+                PsiMethod[] methods = classDataContext.clazz.findMethodsByName(simpleMethodName, false);
+                for (PsiMethod method : methods) {
+                    if (Objects.equals(qualifiedMethodName, IdeClassUtil.getMethodQualifiedName(method))) {
+                        return method;
+                    }
                 }
             }
-        }
-        return null;
+            return null;
+        });
     }
 
     public PsiParameterList getParamList() {
-        PsiMethod method = getMethod();
-        if (Objects.isNull(method)) {
-            return new PsiParameterListImpl(new PsiParameterListStubImpl(null));
-        }
-        return method.getParameterList();
+        return ReadAction.compute(() -> {
+            PsiMethod method = getMethod();
+            if (Objects.isNull(method)) {
+                return new PsiParameterListImpl(new PsiParameterListStubImpl(null));
+            }
+            return method.getParameterList();
+        });
     }
 
     @Override
@@ -177,21 +182,9 @@ public class MethodDataContext implements Multicaster, Listener {
             updateItemName(dataItem);
             flush();
         } else if (Objects.equals(event.getType(), EventType.ADD_SIMPLE_PARAM_ITEM)) {
-            findItem(null)
-                    .ifPresentOrElse(
-                            item -> {
-                                item.setParam(JsonElementUtil.getSimpleText(getParamList()));
-                                selectItem(item);
-                            },
-                            this::resetEmptyItem);
+            resetSimpleParamItem();
         } else if (Objects.equals(event.getType(), EventType.ADD_ALL_PARAM_ITEM)) {
-            findItem(null)
-                    .ifPresentOrElse(
-                            item -> {
-                                item.setParam(JsonElementUtil.getJsonText(getParamList()));
-                                selectItem(item);
-                            },
-                            this::resetEmptyItemFillParam);
+            resetAllParamItem();
         } else if (Objects.equals(event.getType(), EventType.ADD_CACHE_PARAM_ITEM)) {
             resetLastCacheParam();
         }
@@ -204,13 +197,29 @@ public class MethodDataContext implements Multicaster, Listener {
     }
 
     private void resetEmptyItemFillParam() {
-        resetEmptyItem();
-        freeItem.setParam(JsonElementUtil.getJsonText(getParamList()));
+        resetAllParamItem();
     }
 
     private void resetEmptyItem() {
-        freeItem = new ParamDataItem("", qualifiedMethodName, JsonElementUtil.getSimpleText(getParamList()));
+        resetAllParamItem();
+    }
+
+    private void resetSimpleParamItem() {
+        freeItem = new ParamDataItem("", qualifiedMethodName, getSimpleParamText());
         selectItem(freeItem);
+    }
+
+    private void resetAllParamItem() {
+        freeItem = new ParamDataItem("", qualifiedMethodName, getAllParamText());
+        selectItem(freeItem);
+    }
+
+    private String getSimpleParamText() {
+        return ReadAction.compute(() -> JsonElementUtil.getSimpleText(getParamList()));
+    }
+
+    private String getAllParamText() {
+        return ReadAction.compute(() -> JsonElementUtil.getJsonText(getParamList()));
     }
 
     private void resetLastCacheParam() {

--- a/any-door-plugin/src/main/java/io/github/lgp547/anydoorplugin/dialog/components/MainPanel.java
+++ b/any-door-plugin/src/main/java/io/github/lgp547/anydoorplugin/dialog/components/MainPanel.java
@@ -49,7 +49,7 @@ public class MainPanel extends JBPanel<MainPanel> implements Listener {
         this.context = context;
 
         toolBar = new MyToolBar(project, context);
-        editor = new MyEditor(context, context.cacheContent, context.getParamList(), project);
+        editor = new MyEditor(context, context.getSelectedItem().getParam(), context.getParamList(), project);
 //        comboBox = new MyComboBox(project, context);
 //        saveParamButton = new JButton("Save");
         runNum = new JBIntSpinner(1, 1, Integer.MAX_VALUE);

--- a/any-door-plugin/src/main/java/io/github/lgp547/anydoorplugin/util/JsonElementUtil.java
+++ b/any-door-plugin/src/main/java/io/github/lgp547/anydoorplugin/util/JsonElementUtil.java
@@ -10,6 +10,7 @@ import com.google.gson.JsonPrimitive;
 import com.intellij.psi.PsiClass;
 import com.intellij.psi.PsiClassType;
 import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiModifier;
 import com.intellij.psi.PsiParameter;
 import com.intellij.psi.PsiParameterList;
 import com.intellij.psi.PsiType;
@@ -18,7 +19,6 @@ import com.intellij.psi.PsiWhiteSpace;
 import com.intellij.psi.impl.source.tree.LeafPsiElement;
 import com.intellij.psi.impl.source.tree.PsiErrorElementImpl;
 import org.apache.commons.lang3.ClassUtils;
-import org.apache.commons.lang3.StringUtils;
 
 import java.net.URI;
 import java.net.URL;
@@ -99,7 +99,7 @@ public class JsonElementUtil {
                     }
                     JsonObject jsonObject1 = new JsonObject();
                     Arrays.stream(psiClass.getAllFields()).forEach(field -> {
-                        if (!StringUtils.contains(field.getText(), " static ") && num < 5) {
+                        if (!field.hasModifierProperty(PsiModifier.STATIC) && num < 5) {
                             jsonObject1.add(field.getName(), toJson(field.getType(), num + 1));
                         }
                     });

--- a/any-door-plugin/src/test/java/io/github/lgp547/anydoorplugin/action/MethodInvocationSnapshotTest.java
+++ b/any-door-plugin/src/test/java/io/github/lgp547/anydoorplugin/action/MethodInvocationSnapshotTest.java
@@ -1,0 +1,215 @@
+package io.github.lgp547.anydoorplugin.action;
+
+import com.intellij.mock.MockApplication;
+import com.intellij.openapi.Disposable;
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.util.ThrowableComputable;
+import com.intellij.openapi.util.Disposer;
+import com.intellij.psi.PsiAnnotation;
+import com.intellij.psi.PsiClass;
+import com.intellij.psi.PsiMethod;
+import com.intellij.psi.PsiParameter;
+import com.intellij.psi.PsiParameterList;
+import com.intellij.psi.PsiType;
+import com.intellij.psi.PsiTypeVisitor;
+import com.intellij.psi.search.GlobalSearchScope;
+import junit.framework.TestCase;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Proxy;
+import java.util.List;
+import java.util.Map;
+
+public class MethodInvocationSnapshotTest extends TestCase {
+
+    private Disposable disposable;
+    private TrackingMockApplication application;
+
+    @Override
+    protected void setUp() throws Exception {
+        super.setUp();
+        disposable = Disposer.newDisposable();
+        application = new TrackingMockApplication(disposable);
+        ApplicationManager.setApplication(application, disposable);
+    }
+
+    @Override
+    protected void tearDown() throws Exception {
+        try {
+            Disposer.dispose(disposable);
+        } finally {
+            super.tearDown();
+        }
+    }
+
+    public void testCaptureCopiesInterfaceMethodMetadata() {
+        PsiParameter name = parameter("name", new TestPsiType("java.lang.String"));
+        PsiParameter ids = parameter("ids", new TestPsiType("java.util.List<java.lang.Integer>"));
+        PsiParameterList parameters = parameterList(name, ids);
+        PsiClass psiClass = psiClass("demo.SampleService", true);
+        PsiMethod psiMethod = psiMethod("execute", psiClass, parameters);
+
+        MethodInvocationSnapshot snapshot = MethodInvocationSnapshot.capture(psiMethod);
+
+        assertTrue(application.wasReadActionInvoked());
+        assertEquals("demo.SampleService", snapshot.className());
+        assertEquals("execute", snapshot.methodName());
+        assertEquals(
+                "demo.SampleService#execute(java.lang.String,java.util.List<java.lang.Integer>)",
+                snapshot.qualifiedMethodName()
+        );
+        assertEquals(
+                List.of("java.lang.String", "java.util.List"),
+                snapshot.parameterTypeNames()
+        );
+        assertEquals(
+                Map.of("name", "args0", "ids", "args1"),
+                snapshot.parameterNameTransformer()
+        );
+        assertTrue(snapshot.interfaceType());
+    }
+
+    public void testCaptureMarksClassMethodAsNonInterface() {
+        PsiParameterList parameters = parameterList(
+                parameter("count", new TestPsiType("int"))
+        );
+        PsiClass psiClass = psiClass("demo.SampleService", false);
+        PsiMethod psiMethod = psiMethod("execute", psiClass, parameters);
+
+        MethodInvocationSnapshot snapshot = MethodInvocationSnapshot.capture(psiMethod);
+
+        assertTrue(application.wasReadActionInvoked());
+        assertFalse(snapshot.interfaceType());
+        assertEquals(List.of("int"), snapshot.parameterTypeNames());
+        assertEquals(Map.of("count", "args0"), snapshot.parameterNameTransformer());
+    }
+
+    private static PsiClass psiClass(String qualifiedName, boolean interfaceType) {
+        return proxy(PsiClass.class, (proxy, method, args) -> switch (method.getName()) {
+            case "getQualifiedName" -> qualifiedName;
+            case "isInterface" -> interfaceType;
+            case "toString" -> qualifiedName;
+            case "hashCode" -> System.identityHashCode(proxy);
+            case "equals" -> proxy == args[0];
+            default -> throw unsupported(method.getName());
+        });
+    }
+
+    private static PsiMethod psiMethod(
+            String name,
+            PsiClass containingClass,
+            PsiParameterList parameters
+    ) {
+        return proxy(PsiMethod.class, (proxy, method, args) -> switch (method.getName()) {
+            case "getName" -> name;
+            case "getContainingClass" -> containingClass;
+            case "getParent" -> containingClass;
+            case "getParameterList" -> parameters;
+            case "toString" -> name;
+            case "hashCode" -> System.identityHashCode(proxy);
+            case "equals" -> proxy == args[0];
+            default -> throw unsupported(method.getName());
+        });
+    }
+
+    private static PsiParameterList parameterList(PsiParameter... parameters) {
+        return proxy(PsiParameterList.class, (proxy, method, args) -> switch (method.getName()) {
+            case "getParametersCount" -> parameters.length;
+            case "getParameter" -> parameters[(Integer) args[0]];
+            case "getParameters" -> parameters;
+            case "toString" -> List.of(parameters).toString();
+            case "hashCode" -> System.identityHashCode(proxy);
+            case "equals" -> proxy == args[0];
+            default -> throw unsupported(method.getName());
+        });
+    }
+
+    private static PsiParameter parameter(String name, PsiType type) {
+        return proxy(PsiParameter.class, (proxy, method, args) -> switch (method.getName()) {
+            case "getName" -> name;
+            case "getType" -> type;
+            case "toString" -> name;
+            case "hashCode" -> System.identityHashCode(proxy);
+            case "equals" -> proxy == args[0];
+            default -> throw unsupported(method.getName());
+        });
+    }
+
+    private static <T> T proxy(Class<T> type, InvocationHandler handler) {
+        return type.cast(Proxy.newProxyInstance(
+                type.getClassLoader(),
+                new Class<?>[]{type},
+                handler
+        ));
+    }
+
+    private static UnsupportedOperationException unsupported(String methodName) {
+        return new UnsupportedOperationException("Unexpected PSI call: " + methodName);
+    }
+
+    private static final class TestPsiType extends PsiType {
+
+        private final String canonicalText;
+
+        private TestPsiType(String canonicalText) {
+            super(PsiAnnotation.EMPTY_ARRAY);
+            this.canonicalText = canonicalText;
+        }
+
+        @Override
+        public String getPresentableText() {
+            return canonicalText;
+        }
+
+        @Override
+        public String getCanonicalText() {
+            return canonicalText;
+        }
+
+        @Override
+        public boolean isValid() {
+            return true;
+        }
+
+        @Override
+        public boolean equalsToText(String text) {
+            return canonicalText.equals(text);
+        }
+
+        @Override
+        public <A> A accept(PsiTypeVisitor<A> visitor) {
+            return visitor.visitType(this);
+        }
+
+        @Override
+        public GlobalSearchScope getResolveScope() {
+            return GlobalSearchScope.EMPTY_SCOPE;
+        }
+
+        @Override
+        public PsiType[] getSuperTypes() {
+            return PsiType.EMPTY_ARRAY;
+        }
+    }
+
+    private static final class TrackingMockApplication extends MockApplication {
+
+        private boolean readActionInvoked;
+
+        private TrackingMockApplication(Disposable parentDisposable) {
+            super(parentDisposable);
+        }
+
+        @Override
+        public <T, E extends Throwable> T runReadAction(
+                ThrowableComputable<T, E> computation
+        ) throws E {
+            readActionInvoked = true;
+            return super.runReadAction(computation);
+        }
+
+        private boolean wasReadActionInvoked() {
+            return readActionInvoked;
+        }
+    }
+}


### PR DESCRIPTION
## 问题

`MainUI` 和旧参数对话框都是 modeless dialog。用户点击 RUN/OK 时，回调已经离开原 action 的读上下文，但仍直接读取 `PsiClass`、`PsiMethod` 和 `PsiParameterList`，在新版 IntelliJ Platform 上触发：

`Read access is allowed from inside read-action only`

## 修改

- 在展示对话框前，通过一次 `ReadAction.compute` 捕获不可变的 `MethodInvocationSnapshot`
- 新旧 UI 的延迟 OK 回调仅使用普通 Java 快照值，不再读取 PSI
- 保留现有公共入口、缓存键、请求字段和接口参数 `argsN` 转换行为
- HTTP/JVM attach 等非 PSI 操作保持在 read action 之外
- 增加接口方法和普通类方法的回归测试，并验证确实进入 read action

## 验证

- `Gradle check` 通过
- 2 个回归测试通过，0 failures
- `clean buildPlugin` 通过