### PR TITLE
修复 Run/Debug 启动时的 EDT 卡顿

### DIFF
--- a/any-door-plugin/build.gradle.kts
+++ b/any-door-plugin/build.gradle.kts
@@ -1,4 +1,12 @@
+import org.gradle.api.file.DuplicatesStrategy
+import org.gradle.jvm.tasks.Jar
+import org.jetbrains.intellij.tasks.PrepareSandboxTask
+import java.util.zip.ZipFile
+
 fun properties(key: String) = providers.gradleProperty(key)
+
+val anyDoorAllDependenceJarName = "any-door-all-dependence.jar"
+val excludedAnyDoorBundlePrefixes = listOf("any-door", "arthas")
 
 plugins {
     id("java")
@@ -24,6 +32,64 @@ dependencies {
 
 }
 
+val buildAnyDoorAllDependenceJar by tasks.registering(Jar::class) {
+    group = "build"
+    description = "Builds the isolated dependency bundle loaded into the target JVM"
+    archiveFileName.set(anyDoorAllDependenceJarName)
+    destinationDirectory.set(layout.buildDirectory.dir("generated/any-door-agent"))
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+    isPreserveFileTimestamps = false
+    isReproducibleFileOrder = true
+
+    from({
+        configurations.runtimeClasspath.get()
+            .filter { dependency ->
+                dependency.isFile && excludedAnyDoorBundlePrefixes.none(dependency.name::startsWith)
+            }
+            .map(::zipTree)
+    })
+
+    exclude(
+        "META-INF/MANIFEST.MF",
+        "META-INF/INDEX.LIST",
+        "META-INF/*.SF",
+        "META-INF/*.RSA",
+        "META-INF/*.DSA",
+        "module-info.class",
+        "META-INF/versions/*/module-info.class",
+    )
+}
+
+val verifyAnyDoorAllDependenceJar by tasks.registering {
+    group = "verification"
+    description = "Verifies the target-JVM dependency bundle contents"
+    dependsOn(buildAnyDoorAllDependenceJar)
+    inputs.file(buildAnyDoorAllDependenceJar.flatMap { it.archiveFile })
+
+    doLast {
+        val bundle = buildAnyDoorAllDependenceJar.get().archiveFile.get().asFile
+        val requiredEntries = listOf(
+            "com/fasterxml/jackson/databind/ObjectMapper.class",
+            "org/springframework/context/ApplicationContext.class",
+        )
+        val forbiddenEntries = listOf(
+            "io/github/lgp547/anydoor/core/AnyDoorService.class",
+            "io/github/lgp547/anydoor/attach/AnyDoorAttach.class",
+            "arthas/VmTool.class",
+        )
+
+        check(bundle.isFile) { "Missing target-JVM dependency bundle: $bundle" }
+        ZipFile(bundle).use { archive ->
+            requiredEntries.forEach { entry ->
+                check(archive.getEntry(entry) != null) { "Missing required bundle entry: $entry" }
+            }
+            forbiddenEntries.forEach { entry ->
+                check(archive.getEntry(entry) == null) { "Forbidden bundle entry: $entry" }
+            }
+        }
+    }
+}
+
 // Configure Gradle IntelliJ Plugin - read more: https://github.com/JetBrains/gradle-intellij-plugin
 intellij {
     // todo：若没商业版授权，这里改成社区版进行调式
@@ -47,6 +113,10 @@ tasks {
         untilBuild.set(properties("pluginUntilBuild"))
     }
 
+    named("check") {
+        dependsOn(verifyAnyDoorAllDependenceJar)
+    }
+
 //    signPlugin {
 //        certificateChain.set(System.getenv("CERTIFICATE_CHAIN"))
 //        privateKey.set(System.getenv("PRIVATE_KEY"))
@@ -56,4 +126,10 @@ tasks {
 //    publishPlugin {
 //        token.set(System.getenv("PUBLISH_TOKEN"))
 //    }
+}
+
+tasks.withType<PrepareSandboxTask>().configureEach {
+    dependsOn(buildAnyDoorAllDependenceJar)
+    intoChild(pluginName.map { "$it/agent" })
+        .from(buildAnyDoorAllDependenceJar.flatMap { it.archiveFile })
 }

--- a/any-door-plugin/src/main/java/io/github/lgp547/anydoorplugin/action/AnyDoorPerformed.java
+++ b/any-door-plugin/src/main/java/io/github/lgp547/anydoorplugin/action/AnyDoorPerformed.java
@@ -138,7 +138,7 @@ public class AnyDoorPerformed {
         jsonObjectReq.add("parameterTypes", JsonUtil.toJsonArray(paramTypeNameList));
 
         String anyDoorJarPath = ImportNewUtil.getPluginLibPath(AnyDoorInfo.ANY_DOOR_JAR);
-        String dependenceJarFilePath = ImportNewUtil.getPluginLibPath(AnyDoorInfo.ANY_DOOR_ALL_DEPENDENCE_JAR);
+        String dependenceJarFilePath = ImportNewUtil.getPluginAgentPath(AnyDoorInfo.ANY_DOOR_ALL_DEPENDENCE_JAR);
         String anyDoorCommonJarPath = ImportNewUtil.getPluginLibPath(AnyDoorInfo.ANY_DOOR_COMMON_JAR);
         jsonObjectReq.add("jarPaths", JsonUtil.toJsonArray(List.of(anyDoorJarPath, dependenceJarFilePath, anyDoorCommonJarPath)));
         jsonObjectReq.addProperty("projectBasePath", project.getBasePath());

--- a/any-door-plugin/src/main/java/io/github/lgp547/anydoorplugin/listener/ExecutionListenerImpl.java
+++ b/any-door-plugin/src/main/java/io/github/lgp547/anydoorplugin/listener/ExecutionListenerImpl.java
@@ -8,9 +8,7 @@ import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.projectRoots.Sdk;
 import com.intellij.openapi.roots.ProjectRootManager;
-import io.github.lgp547.anydoorplugin.AnyDoorInfo;
 import io.github.lgp547.anydoorplugin.settings.AnyDoorSettingsState;
-import io.github.lgp547.anydoorplugin.util.ImportNewUtil;
 import io.github.lgp547.anydoorplugin.util.NotifierUtil;
 import io.github.lgp547.anydoorplugin.util.RuntimeUtil;
 import org.apache.commons.lang3.StringUtils;
@@ -20,11 +18,6 @@ import org.jetbrains.annotations.NotNull;
 public class ExecutionListenerImpl implements ExecutionListener {
 
     private static final Logger log = Logger.getInstance(ExecutionListenerImpl.class);
-
-    @Override
-    public void processStartScheduled(@NotNull String executorId, @NotNull ExecutionEnvironment env) {
-        ImportNewUtil.checkAndGenJar(env.getProject(), AnyDoorInfo.ANY_DOOR_ALL_DEPENDENCE_JAR);
-    }
 
     @Override
     public void processStarting(@NotNull String executorId, @NotNull ExecutionEnvironment env, @NotNull ProcessHandler handler) {

--- a/any-door-plugin/src/main/java/io/github/lgp547/anydoorplugin/util/ImportNewUtil.java
+++ b/any-door-plugin/src/main/java/io/github/lgp547/anydoorplugin/util/ImportNewUtil.java
@@ -8,28 +8,28 @@ import com.intellij.openapi.roots.ModuleRootModificationUtil;
 import com.intellij.openapi.roots.libraries.Library;
 import com.intellij.openapi.roots.libraries.LibraryTable;
 import io.github.lgp547.anydoorplugin.AnyDoorInfo;
-import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
 import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
-import java.util.jar.JarEntry;
-import java.util.jar.JarInputStream;
-import java.util.jar.JarOutputStream;
 
 public class ImportNewUtil {
 
     public static String getPluginBasePath() {
-        return PathManager.getPluginsPath() + File.separator + "any-door-plugin" + File.separator + "lib";
+        return getPluginPath() + File.separator + "lib";
+    }
+
+    public static String getPluginAgentPath(String fileName) {
+        return getPluginPath() + File.separator + "agent" + File.separator + fileName;
+    }
+
+    private static String getPluginPath() {
+        return PathManager.getPluginsPath() + File.separator + "any-door-plugin";
     }
 
 //    public static String getPluginLibPath(String libraryName, String libraryVersion) {
@@ -79,82 +79,6 @@ public class ImportNewUtil {
 //            }
 //        }
 //    }
-
-    public static void checkAndGenJar(@NotNull Project project, String anyDoorAllDependenceJar) {
-        try {
-            String dependenceJarFilePath = getPluginLibPath(anyDoorAllDependenceJar);
-            if (new File(dependenceJarFilePath).exists()) {
-                return;
-            }
-            File[] dependenceJars = new File(getPluginBasePath()).listFiles(curFile ->
-                    !StringUtils.startsWithAny(curFile.getName(), AnyDoorInfo.ANY_DOOR_NAME, "arthas") && StringUtils.endsWith(curFile.getName(), ".jar"));
-            if (dependenceJars != null && dependenceJars.length != 0) {
-                genAllDependenceFile(dependenceJars, dependenceJarFilePath);
-                NotifierUtil.notifyInfo(project, String.format("%s dependence gen %s", dependenceJars.length, dependenceJarFilePath));
-            } else {
-                NotifierUtil.notifyError(project, "dependence jar is empty.Please check the path:" + dependenceJarFilePath);
-            }
-        } catch (Exception e) {
-            NotifierUtil.notifyError(project, anyDoorAllDependenceJar + " does not exist. errMsg:" + e.getMessage());
-        }
-    }
-
-    private static void genAllDependenceFile(File[] dependenceJars, String dependenceJarFilePath) throws IOException {
-        FileOutputStream out = new FileOutputStream(dependenceJarFilePath);
-        JarOutputStream jos = new JarOutputStream(out);
-
-        Path tempDirectory = Files.createTempDirectory(AnyDoorInfo.ANY_DOOR_NAME);
-        for (File jarFile : dependenceJars) {
-            FileInputStream fis = new FileInputStream(jarFile);
-            JarInputStream jis = new JarInputStream(fis);
-
-            byte[] buffer = new byte[1024];
-            int bytesRead = 0;
-            JarEntry entry = null;
-            while ((entry = jis.getNextJarEntry()) != null) {
-                if (entry.isDirectory()) {
-                    continue;
-                }
-                File tempFile = new File(tempDirectory + "/" + entry.getName());
-                if (!tempFile.exists()) {
-                    tempFile.getParentFile().mkdirs();
-                }
-
-                FileOutputStream tempFileOut = new FileOutputStream(tempFile.getPath());
-                while ((bytesRead = jis.read(buffer)) != -1) {
-                    tempFileOut.write(buffer, 0, bytesRead);
-                }
-                tempFileOut.close();
-
-                jis.closeEntry();
-            }
-
-            jis.close();
-            fis.close();
-        }
-
-
-        copyJarFile(tempDirectory.toString(), jos, tempDirectory.toFile().listFiles());
-        jos.close();
-        out.close();
-        FileUtils.deleteDirectory(tempDirectory.toFile());
-    }
-
-    private static void copyJarFile(String basePath, JarOutputStream jos, File[] files) throws IOException {
-        if (null == files) {
-            return;
-        }
-        for (File file : files) {
-            if (file.isDirectory()) {
-                copyJarFile(basePath, jos, file.listFiles());
-                continue;
-            }
-            String jarEntryName = file.getAbsolutePath().substring(basePath.length() + 1);
-            jarEntryName = StringUtils.replace(jarEntryName, "\\", "/");
-            jos.putNextEntry(new JarEntry(jarEntryName));
-            Files.copy(file.toPath(), jos);
-        }
-    }
 
     public static void fillAnyDoorJar(Project project, String moduleName) {
         try {


### PR DESCRIPTION
## 问题

AnyDoor 在 Run/Debug 启动事件中同步解压、合并并清理依赖 JAR。该监听回调运行在 EDT，磁盘操作可能阻塞界面十余秒并触发 `com.intellij.diagnostic.Freeze`。

## 根因

`ExecutionListenerImpl#processStartScheduled` 直接调用 `ImportNewUtil#checkAndGenJar`，后者在 IDE 运行时执行临时目录创建、依赖解压、递归复制、JAR 写入和目录清理。

## 修改

- 新增 Gradle `buildAnyDoorAllDependenceJar`，在插件构建期生成目标 JVM 所需的外部依赖包。
- 新增 `verifyAnyDoorAllDependenceJar` 并接入 `check`，验证必需类存在且 AnyDoor/Arthas 实现类未被合入。
- 将合并包放入插件的 `agent/` 目录，避免与 `lib/` 的原始依赖形成重复插件类路径。
- 删除 `processStartScheduled` 中的运行时 JAR 生成，以及临时目录解压、递归复制和清理实现。
- Attach 请求改为读取已打包的 `agent/any-door-all-dependence.jar`。

## 验证

- `clean check buildPlugin` 通过。
- 2 个回归测试通过，0 failure，0 error。
- 分发 ZIP 包含 `any-door-plugin/agent/any-door-all-dependence.jar`，且 `lib/` 下不存在同名合并包。
- 合并包包含 Jackson、Spring 必需类，不包含 AnyDoor Core、Attach 或 Arthas 实现类。
- 合并包共 4242 个条目，重复构建 SHA-256 一致。
- 生产源码中不再存在 `checkAndGenJar`、`genAllDependenceFile` 或 `copyJarFile` 运行时生成路径。

## 关联

- #63 已合并并包含此前的 PSI Read Action 修复；本 PR 仅包含新的 EDT Freeze 修复。